### PR TITLE
Added support for packaging into PyPi. This will let people 'pip inst…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from distutils.core import setup
+setup(
+  name = 'FortigateApi',
+  packages = ['FortigateApi'], # this must be the same as the name above
+  version = '0.1',
+  description = 'Access Fortigate REST API in python',
+  author = 'David Chayla',
+  author_email = 'null',
+  url = 'https://github.com/DavidChayla/FortigateApi', 
+  download_url = 'https://github.com/DavidChayla/FortigateApi/archive/0.1.tar.gz', 
+  keywords = ['fortigate', 'REST', 'network'],
+  classifiers = [],
+)


### PR DESCRIPTION
…all FortigateApi'

Hi David,

I've added support for your repo to be included in Pypi. If you're unwilling to submit it, I'll gladly take care of maintaining a branch with Pypi support. I think it would benefit everyone to have this API available as a pip install module, so that it can be built on top of. I'd like to use it within my NetSpark-Scripts project, for instance. 

Do let me know if you're willing to do it or if I should maintain the pypi package. If I don't hear back in a few days, I'll assume the project has been abandoned and will submit my fork (retaining your copyright per the GPLv3).

Here is a good guide on the process for doing this: http://peterdowns.com/posts/first-time-with-pypi.html

Regards,

-AdmiralSpark