### PR TITLE
URL should contain object name when deleting fw addr and fw addr group

### DIFF
--- a/FortigateApi.py
+++ b/FortigateApi.py
@@ -921,7 +921,7 @@ class Fortigate:
                     'name': name
                     }
                 }
-        return self.ApiDelete('cmdb/firewall/address/', data=payload)
+        return self.ApiDelete('cmdb/firewall/address/' + 'name' + '/', data=payload)
 
     def DelAllFwAddress(self):
         """
@@ -1048,7 +1048,7 @@ class Fortigate:
                     'name': name
                     }     
                 }
-        return self.ApiDelete('cmdb/firewall/addrgrp/', payload)
+        return self.ApiDelete('cmdb/firewall/addrgrp/' + name + '/', payload)
     
     def DelAllFwAddressGroup(self):
         """


### PR DESCRIPTION
URL should contain object name when deleting firewall address and firewall address group, or Fortigate will do purge and delete all objects which has no references.